### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/salioglu/sphinx-ultra/security/code-scanning/6](https://github.com/salioglu/sphinx-ultra/security/code-scanning/6)

To resolve this issue, you should set explicit permissions for the workflow to restrict the access of the `GITHUB_TOKEN`. The minimal required permission for this workflow is likely `contents: read`, since all jobs only interact with the codebase and external services, and none appear to need write access to repository contents or other resources (e.g., issues, pull-requests). The optimal fix is to add a `permissions` block at the root level of `.github/workflows/ci.yml`—before `jobs:`—so it applies to all jobs. If any individual job requires additional permissions, those can be set separately, but in this case, all jobs appear to only need read access.

This change should be made at the top of `.github/workflows/ci.yml`, right after the `name` and `on` blocks, and before `env` or `jobs`. No additional imports or package installations are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
